### PR TITLE
cicd: fix golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
 
@@ -22,9 +22,9 @@ jobs:
 
       # Check #1: Lint
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43.0
+          version: v1.47.2
 
       # Check #2: Test & generate coverage report
       - name: Test & coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: go get github.com/ory/go-acc
 
       # Check #1: Lint
-      - name: golangci-lint
+      - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.47.2
@@ -30,8 +30,8 @@ jobs:
       - name: Test & coverage
         run: make test-cov
 
-      # Check #3: Build
-      - name: Build Server
+      # Check #3: Build binaries
+      - name: Build
         run: make build
 
       - name: Upload coverage report


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Fixes CI by upgrading CI deps (actions versions + `golangci-lint` version)

Also made environment secret `CODECOV_TOKEN` available from this repository

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
