### PR TITLE
ci: fix newer version golangci-lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,7 +111,7 @@ linters-settings:
     extra-rules: true
 
   goimports:
-    local-prefixes: github.com/benchttp/runner
+    local-prefixes: github.com/benchttp/engine
 
   misspell:
     locale: US

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,6 +20,7 @@ func main() {
 	addr := ":" + port
 	fmt.Println("http://localhost" + addr)
 
+	//#nosec G114 -- Ignored for convenience
 	log.Fatal(http.ListenAndServe(addr, http.HandlerFunc(handleStream)))
 }
 

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -18,7 +18,8 @@ func WriteRecordingProgress(w io.Writer, s runner.RecordingProgress) (int, error
 
 // renderProgress returns a string representation of runner.RecordingProgress
 // for a fancy display in a CLI:
-// 	RUNNING ◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎ 50% | 50/100 requests | 27s timeout
+//
+//	RUNNING ◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎ 50% | 50/100 requests | 27s timeout
 func renderProgress(s runner.RecordingProgress) string {
 	var (
 		countdown = s.Timeout - s.Elapsed
@@ -51,7 +52,8 @@ var (
 )
 
 // renderTimeline returns a colored representation of the progress as a string:
-// 	◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎
+//
+//	◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎
 func renderTimeline(pctdone int) string {
 	tl := strings.Repeat(tlBlockGrey, tlLen)
 	for i := 0; i < tlLen; i++ {

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -33,9 +33,11 @@ func New(numWorker int) Dispatcher {
 // or canceled. Concurrency is handled leveraging the semaphore pattern, which
 // ensures at most Dispatcher.numWorkers goroutines are spawned at the same time.
 // It returns an early ErrInvalidValue if any of the following conditions is met:
-// 	maxIter < 1 and maxIter != -1
-// 	maxIter > numWorker
-// 	callback == nil
+//
+//	maxIter < 1 and maxIter != -1
+//	maxIter > numWorker
+//	callback == nil
+//
 // Else it returns the context error if any or nil.
 func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) error {
 	if err := d.validate(maxIter, callback); err != nil {

--- a/internal/errorutil/errorutil.go
+++ b/internal/errorutil/errorutil.go
@@ -9,11 +9,12 @@ import (
 // representation of details separated by ": ".
 //
 // Example
-// 	var ErrNotFound = errors.New("not found")
-// 	err := WithDetails(ErrNotFound, "abc.jpg", "deleted yesterday")
 //
-// 	errors.Is(err, ErrNotFound) == true
-// 	err.Error() == "not found: abc.jpg: deleted yesterday"
+//	var ErrNotFound = errors.New("not found")
+//	err := WithDetails(ErrNotFound, "abc.jpg", "deleted yesterday")
+//
+//	errors.Is(err, ErrNotFound) == true
+//	err.Error() == "not found: abc.jpg: deleted yesterday"
 func WithDetails(base error, details ...interface{}) error {
 	detailsStr := make([]string, len(details))
 	for i := range details {

--- a/runner/internal/metrics/field.go
+++ b/runner/internal/metrics/field.go
@@ -62,8 +62,9 @@ const (
 // String returns a human-readable representation of the field.
 //
 // Example:
-// 	TypeDuration.String() == "time.Duration"
-// 	Type(123).String() == "[unknown type]"
+//
+//	TypeDuration.String() == "time.Duration"
+//	Type(123).String() == "[unknown type]"
 func (typ Type) String() string {
 	switch typ {
 	case TypeInt:

--- a/runner/internal/metrics/metrics.go
+++ b/runner/internal/metrics/metrics.go
@@ -20,17 +20,17 @@ type Metric struct {
 //
 // Examples:
 //
-// 	receiver := Metric{Value: 120}
-// 	comparer := Metric{Value: 100}
-// 	receiver.Compare(comparer) == SUP
+//	receiver := Metric{Value: 120}
+//	comparer := Metric{Value: 100}
+//	receiver.Compare(comparer) == SUP
 //
-// 	receiver := Metric{Value: 120 * time.Millisecond}
-// 	comparer := Metric{Value: 100}
-// 	receiver.Compare(comparer) // panics!
+//	receiver := Metric{Value: 120 * time.Millisecond}
+//	comparer := Metric{Value: 100}
+//	receiver.Compare(comparer) // panics!
 //
-// 	receiver := Metric{Value: http.Header{}}
-// 	comparer := Metric{Value: http.Header{}}
-// 	receiver.Compare(comparer) // panics!
+//	receiver := Metric{Value: http.Header{}}
+//	comparer := Metric{Value: http.Header{}}
+//	receiver.Compare(comparer) // panics!
 func (m Metric) Compare(to Metric) ComparisonResult {
 	return compareMetrics(to, m)
 }


### PR DESCRIPTION
## Description

`golanci-lint` will only support the 2 latest version of go (1.18 and 1.19).
Pinning a previous version in the gihtub action seems to not work as expected.
After investigations the rules which produces ci fails are easy to fix manually. This PR offer this fix and some related ones.

## Changes

The breaking changes in `golangci-lint` comes from go 1.19 new `go fmt` rules for body of code in documentation comments:

```go
// A comment with a white space and a tab produces 'File is not `gofumpt`-ed with `-extra` (gofumpt)'
// 	a := Foo()
func Foo() Type {}

// A comment with only a tab is `gofumpt`-ed. There is no error
//	a := Foo()
func Foo() Type {}
```

- fixes `gofumpt` errors 
- fixes a dead reference to `benchttp/runner` instead of `benchttp/engine` in `goimports:local-prefixes` of `golangci-lint` configuration
- fixes `gosec` error (`G114: Use of net/http serve function that has no support for setting timeouts`) for `http.ListenAndServe`: we may ignore it for convenience
