### PR TITLE
fix(server): conventional camel-cased JSON responses

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/joho/godotenv"
 
+	"github.com/benchttp/engine/cmd/server/response"
 	"github.com/benchttp/engine/internal/configparse"
 	"github.com/benchttp/engine/runner"
 )
@@ -99,7 +100,7 @@ func handleStream(w http.ResponseWriter, r *http.Request) {
 	// The issue is likely on the read side (front-end), but this is
 	// the easiest fix for now.
 	time.Sleep(10 * time.Millisecond)
-	if err := toReportResponse(rep).EncodeJSON(w); err != nil {
+	if err := response.Report(rep).EncodeJSON(w); err != nil {
 		internalError(w, err)
 		return
 	}
@@ -107,7 +108,7 @@ func handleStream(w http.ResponseWriter, r *http.Request) {
 
 func streamProgress(w http.ResponseWriter) func(runner.RecordingProgress) {
 	return func(progress runner.RecordingProgress) {
-		if err := toProgressResponse(progress).EncodeJSON(w); err != nil {
+		if err := response.Progress(progress).EncodeJSON(w); err != nil {
 			internalError(w, err)
 		}
 		w.(http.Flusher).Flush()
@@ -119,7 +120,7 @@ func internalError(w http.ResponseWriter, e error) {
 
 	w.WriteHeader(http.StatusInternalServerError)
 
-	if err := toErrorResponse(e).EncodeJSON(w); err != nil {
+	if err := response.Error(e).EncodeJSON(w); err != nil {
 		// Fallback to plain text encoding.
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,9 +107,8 @@ func handleStream(w http.ResponseWriter, r *http.Request) {
 }
 
 func streamProgress(w http.ResponseWriter) func(runner.RecordingProgress) {
-	enc := json.NewEncoder(w)
 	return func(progress runner.RecordingProgress) {
-		if err := enc.Encode(progress); err != nil {
+		if err := toProgressResponse(progress).EncodeJSON(w); err != nil {
 			internalError(w, err)
 		}
 		w.(http.Flusher).Flush()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -100,7 +100,7 @@ func handleStream(w http.ResponseWriter, r *http.Request) {
 	// The issue is likely on the read side (front-end), but this is
 	// the easiest fix for now.
 	time.Sleep(10 * time.Millisecond)
-	if err := json.NewEncoder(w).Encode(rep); err != nil {
+	if err := toReportResponse(rep).EncodeJSON(w); err != nil {
 		internalError(w, err)
 		return
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -115,13 +114,12 @@ func streamProgress(w http.ResponseWriter) func(runner.RecordingProgress) {
 	}
 }
 
-func internalError(w http.ResponseWriter, err error) {
-	stderr.Println(err.Error())
+func internalError(w http.ResponseWriter, e error) {
+	stderr.Println(e)
 
 	w.WriteHeader(http.StatusInternalServerError)
-	e := struct{ Error string }{err.Error()}
 
-	if err := json.NewEncoder(w).Encode(e); err != nil {
+	if err := toErrorResponse(e).EncodeJSON(w); err != nil {
 		// Fallback to plain text encoding.
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/cmd/server/response.go
+++ b/cmd/server/response.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/benchttp/engine/runner"
+)
+
+type reportResponse struct {
+	Metadata metadataResponse `json:"metadata"`
+	Metrics  metricsResponse  `json:"metrics"`
+	Tests    testsResponse    `json:"tests"`
+}
+
+func (resp reportResponse) EncodeJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+type metadataResponse struct {
+	FinishedAt    time.Time     `json:"finishedAt"`
+	TotalDuration time.Duration `json:"totalDuration"`
+}
+
+type testsResponse struct {
+	Pass    bool                 `json:"pass"`
+	Results []testResultResponse `json:"results"`
+}
+
+type testResultResponse struct {
+	Pass    bool              `json:"pass"`
+	Summary string            `json:"summary"`
+	Input   testInputResponse `json:"input"`
+}
+
+type testInputResponse struct {
+	Name      string      `json:"name"`
+	Field     string      `json:"field"`
+	Predicate string      `json:"predicate"`
+	Target    interface{} `json:"target"`
+}
+
+type metricsResponse struct {
+	ResponseTimes           timeStatsResponse            `json:"responseTimes"`
+	StatusCodesDistribution map[int]int                  `json:"statusCodesDistribution"`
+	RequestEventTimes       map[string]timeStatsResponse `json:"requestEventTimes"`
+	Records                 []recordReponse              `json:"records"`
+	RequestFailures         []requestFailureResponse     `json:"requestFailures"`
+	RequestCount            int                          `json:"requestCount"`
+	RequestSuccessCount     int                          `json:"requestSuccessCount"`
+	RequestFailureCount     int                          `json:"requestFailureCount"`
+}
+
+type timeStatsResponse struct {
+	Min       time.Duration   `json:"min"`
+	Max       time.Duration   `json:"max"`
+	Mean      time.Duration   `json:"mean"`
+	Median    time.Duration   `json:"median"`
+	StdDev    time.Duration   `json:"standardDeviation"`
+	Quartiles []time.Duration `json:"quartiles"`
+	Deciles   []time.Duration `json:"deciles"`
+}
+
+type recordReponse struct {
+	ResponseTime time.Duration `json:"responseTime"`
+}
+
+type requestFailureResponse struct {
+	Reason string `json:"reason"`
+}
+
+func toReportResponse(rep *runner.Report) reportResponse {
+	return reportResponse{
+		Metadata: metadataResponse{
+			FinishedAt:    rep.Metadata.FinishedAt,
+			TotalDuration: rep.Metadata.TotalDuration,
+		},
+		Tests: testsResponse{
+			Pass:    rep.Tests.Pass,
+			Results: toTestResultsResponse(rep.Tests.Results),
+		},
+		Metrics: metricsResponse{
+			ResponseTimes:           toTimeStatsResponse(rep.Metrics.ResponseTimes),
+			StatusCodesDistribution: rep.Metrics.StatusCodesDistribution,
+			RequestEventTimes:       toRequestEventTimesResponse(rep.Metrics.RequestEventTimes),
+			Records:                 toRecordsResponse(rep.Metrics.Records),
+			RequestFailures:         toRequestFailuresResponse(rep.Metrics.RequestFailures),
+			RequestCount:            rep.Metrics.RequestCount(),
+			RequestSuccessCount:     rep.Metrics.RequestSuccessCount(),
+			RequestFailureCount:     rep.Metrics.RequestFailureCount(),
+		},
+	}
+}
+
+func toTestResultsResponse(testResults []runner.TestCaseResult) []testResultResponse {
+	resp := make([]testResultResponse, len(testResults))
+	for i, r := range testResults {
+		resp[i] = testResultResponse{
+			Pass:    r.Pass,
+			Summary: r.Summary,
+			Input: testInputResponse{
+				Name:      r.Input.Name,
+				Field:     string(r.Input.Field),
+				Predicate: string(r.Input.Predicate),
+				Target:    r.Input.Target,
+			},
+		}
+	}
+	return resp
+}
+
+func toTimeStatsResponse(stats runner.MetricsTimeStats) timeStatsResponse {
+	return timeStatsResponse{
+		Min:       stats.Min,
+		Max:       stats.Max,
+		Mean:      stats.Mean,
+		Median:    stats.Median,
+		StdDev:    stats.StdDev,
+		Quartiles: stats.Quartiles,
+		Deciles:   stats.Deciles,
+	}
+}
+
+func toRequestEventTimesResponse(in map[string]runner.MetricsTimeStats) map[string]timeStatsResponse {
+	resp := map[string]timeStatsResponse{}
+	for k, v := range in {
+		resp[k] = toTimeStatsResponse(v)
+	}
+	return resp
+}
+
+func toRecordsResponse(in []struct{ ResponseTime time.Duration }) []recordReponse {
+	resp := make([]recordReponse, len(in))
+	for i, v := range in {
+		resp[i] = recordReponse{ResponseTime: v.ResponseTime}
+	}
+	return resp
+}
+
+func toRequestFailuresResponse(in []struct{ Reason string }) []requestFailureResponse {
+	resp := make([]requestFailureResponse, len(in))
+	for i, v := range in {
+		resp[i] = requestFailureResponse{Reason: v.Reason}
+	}
+	return resp
+}

--- a/cmd/server/response.go
+++ b/cmd/server/response.go
@@ -145,3 +145,29 @@ func toRequestFailuresResponse(in []struct{ Reason string }) []requestFailureRes
 	}
 	return resp
 }
+
+type progressResponse struct {
+	ID        int           `json:"id"`
+	Done      bool          `json:"done"`
+	Error     error         `json:"error"`
+	DoneCount int           `json:"doneCount"`
+	MaxCount  int           `json:"maxCount"`
+	Timeout   time.Duration `json:"timeout"`
+	Elapsed   time.Duration `json:"elapsed"`
+}
+
+func (resp progressResponse) EncodeJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+func toProgressResponse(in runner.RecordingProgress) progressResponse {
+	return progressResponse{
+		ID:        in.ID,
+		Done:      in.Done,
+		Error:     in.Error,
+		DoneCount: in.DoneCount,
+		MaxCount:  in.MaxCount,
+		Timeout:   in.Timeout,
+		Elapsed:   in.Elapsed,
+	}
+}

--- a/cmd/server/response.go
+++ b/cmd/server/response.go
@@ -171,3 +171,15 @@ func toProgressResponse(in runner.RecordingProgress) progressResponse {
 		Elapsed:   in.Elapsed,
 	}
 }
+
+type errorResponse struct {
+	Error error `json:"error"`
+}
+
+func (resp errorResponse) EncodeJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+func toErrorResponse(err error) errorResponse {
+	return errorResponse{Error: err}
+}

--- a/cmd/server/response/error.go
+++ b/cmd/server/response/error.go
@@ -1,18 +1,9 @@
 package response
 
-import (
-	"encoding/json"
-	"io"
-)
+func Error(err error) Response {
+	return newResponse(errorResponse{Error: err})
+}
 
-type ErrorResponse struct {
+type errorResponse struct {
 	Error error `json:"error"`
-}
-
-func (resp ErrorResponse) EncodeJSON(w io.Writer) error {
-	return json.NewEncoder(w).Encode(resp)
-}
-
-func Error(err error) ErrorResponse {
-	return ErrorResponse{Error: err}
 }

--- a/cmd/server/response/error.go
+++ b/cmd/server/response/error.go
@@ -1,0 +1,18 @@
+package response
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type ErrorResponse struct {
+	Error error `json:"error"`
+}
+
+func (resp ErrorResponse) EncodeJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+func Error(err error) ErrorResponse {
+	return ErrorResponse{Error: err}
+}

--- a/cmd/server/response/progress.go
+++ b/cmd/server/response/progress.go
@@ -1,0 +1,35 @@
+package response
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/benchttp/engine/runner"
+)
+
+type ProgressResponse struct {
+	ID        int           `json:"id"`
+	Done      bool          `json:"done"`
+	Error     error         `json:"error"`
+	DoneCount int           `json:"doneCount"`
+	MaxCount  int           `json:"maxCount"`
+	Timeout   time.Duration `json:"timeout"`
+	Elapsed   time.Duration `json:"elapsed"`
+}
+
+func (resp ProgressResponse) EncodeJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+func Progress(in runner.RecordingProgress) ProgressResponse {
+	return ProgressResponse{
+		ID:        in.ID,
+		Done:      in.Done,
+		Error:     in.Error,
+		DoneCount: in.DoneCount,
+		MaxCount:  in.MaxCount,
+		Timeout:   in.Timeout,
+		Elapsed:   in.Elapsed,
+	}
+}

--- a/cmd/server/response/progress.go
+++ b/cmd/server/response/progress.go
@@ -1,29 +1,13 @@
 package response
 
 import (
-	"encoding/json"
-	"io"
 	"time"
 
 	"github.com/benchttp/engine/runner"
 )
 
-type ProgressResponse struct {
-	ID        int           `json:"id"`
-	Done      bool          `json:"done"`
-	Error     error         `json:"error"`
-	DoneCount int           `json:"doneCount"`
-	MaxCount  int           `json:"maxCount"`
-	Timeout   time.Duration `json:"timeout"`
-	Elapsed   time.Duration `json:"elapsed"`
-}
-
-func (resp ProgressResponse) EncodeJSON(w io.Writer) error {
-	return json.NewEncoder(w).Encode(resp)
-}
-
-func Progress(in runner.RecordingProgress) ProgressResponse {
-	return ProgressResponse{
+func Progress(in runner.RecordingProgress) Response {
+	return newResponse(progressResponse{
 		ID:        in.ID,
 		Done:      in.Done,
 		Error:     in.Error,
@@ -31,5 +15,15 @@ func Progress(in runner.RecordingProgress) ProgressResponse {
 		MaxCount:  in.MaxCount,
 		Timeout:   in.Timeout,
 		Elapsed:   in.Elapsed,
-	}
+	})
+}
+
+type progressResponse struct {
+	ID        int           `json:"id"`
+	Done      bool          `json:"done"`
+	Error     error         `json:"error"`
+	DoneCount int           `json:"doneCount"`
+	MaxCount  int           `json:"maxCount"`
+	Timeout   time.Duration `json:"timeout"`
+	Elapsed   time.Duration `json:"elapsed"`
 }

--- a/cmd/server/response/progress.go
+++ b/cmd/server/response/progress.go
@@ -8,7 +8,6 @@ import (
 
 func Progress(in runner.RecordingProgress) Response {
 	return newResponse(progressResponse{
-		ID:        in.ID,
 		Done:      in.Done,
 		Error:     in.Error,
 		DoneCount: in.DoneCount,
@@ -19,7 +18,6 @@ func Progress(in runner.RecordingProgress) Response {
 }
 
 type progressResponse struct {
-	ID        int           `json:"id"`
 	Done      bool          `json:"done"`
 	Error     error         `json:"error"`
 	DoneCount int           `json:"doneCount"`

--- a/cmd/server/response/report.go
+++ b/cmd/server/response/report.go
@@ -1,21 +1,38 @@
 package response
 
 import (
-	"encoding/json"
-	"io"
 	"time"
 
 	"github.com/benchttp/engine/runner"
 )
 
-type ReportResponse struct {
+func Report(rep *runner.Report) Response {
+	return newResponse(reportResponse{
+		Metadata: metadataResponse{
+			FinishedAt:    rep.Metadata.FinishedAt,
+			TotalDuration: rep.Metadata.TotalDuration,
+		},
+		Tests: testsResponse{
+			Pass:    rep.Tests.Pass,
+			Results: toTestResultsResponse(rep.Tests.Results),
+		},
+		Metrics: metricsResponse{
+			ResponseTimes:           toTimeStatsResponse(rep.Metrics.ResponseTimes),
+			StatusCodesDistribution: rep.Metrics.StatusCodesDistribution,
+			RequestEventTimes:       toRequestEventTimesResponse(rep.Metrics.RequestEventTimes),
+			Records:                 toRecordsResponse(rep.Metrics.Records),
+			RequestFailures:         toRequestFailuresResponse(rep.Metrics.RequestFailures),
+			RequestCount:            rep.Metrics.RequestCount(),
+			RequestSuccessCount:     rep.Metrics.RequestSuccessCount(),
+			RequestFailureCount:     rep.Metrics.RequestFailureCount(),
+		},
+	})
+}
+
+type reportResponse struct {
 	Metadata metadataResponse `json:"metadata"`
 	Metrics  metricsResponse  `json:"metrics"`
 	Tests    testsResponse    `json:"tests"`
-}
-
-func (resp ReportResponse) EncodeJSON(w io.Writer) error {
-	return json.NewEncoder(w).Encode(resp)
 }
 
 type metadataResponse struct {
@@ -68,29 +85,6 @@ type recordReponse struct {
 
 type requestFailureResponse struct {
 	Reason string `json:"reason"`
-}
-
-func Report(rep *runner.Report) ReportResponse {
-	return ReportResponse{
-		Metadata: metadataResponse{
-			FinishedAt:    rep.Metadata.FinishedAt,
-			TotalDuration: rep.Metadata.TotalDuration,
-		},
-		Tests: testsResponse{
-			Pass:    rep.Tests.Pass,
-			Results: toTestResultsResponse(rep.Tests.Results),
-		},
-		Metrics: metricsResponse{
-			ResponseTimes:           toTimeStatsResponse(rep.Metrics.ResponseTimes),
-			StatusCodesDistribution: rep.Metrics.StatusCodesDistribution,
-			RequestEventTimes:       toRequestEventTimesResponse(rep.Metrics.RequestEventTimes),
-			Records:                 toRecordsResponse(rep.Metrics.Records),
-			RequestFailures:         toRequestFailuresResponse(rep.Metrics.RequestFailures),
-			RequestCount:            rep.Metrics.RequestCount(),
-			RequestSuccessCount:     rep.Metrics.RequestSuccessCount(),
-			RequestFailureCount:     rep.Metrics.RequestFailureCount(),
-		},
-	}
 }
 
 func toTestResultsResponse(testResults []runner.TestCaseResult) []testResultResponse {

--- a/cmd/server/response/report.go
+++ b/cmd/server/response/report.go
@@ -1,4 +1,4 @@
-package main
+package response
 
 import (
 	"encoding/json"
@@ -8,13 +8,13 @@ import (
 	"github.com/benchttp/engine/runner"
 )
 
-type reportResponse struct {
+type ReportResponse struct {
 	Metadata metadataResponse `json:"metadata"`
 	Metrics  metricsResponse  `json:"metrics"`
 	Tests    testsResponse    `json:"tests"`
 }
 
-func (resp reportResponse) EncodeJSON(w io.Writer) error {
+func (resp ReportResponse) EncodeJSON(w io.Writer) error {
 	return json.NewEncoder(w).Encode(resp)
 }
 
@@ -70,8 +70,8 @@ type requestFailureResponse struct {
 	Reason string `json:"reason"`
 }
 
-func toReportResponse(rep *runner.Report) reportResponse {
-	return reportResponse{
+func Report(rep *runner.Report) ReportResponse {
+	return ReportResponse{
 		Metadata: metadataResponse{
 			FinishedAt:    rep.Metadata.FinishedAt,
 			TotalDuration: rep.Metadata.TotalDuration,
@@ -144,42 +144,4 @@ func toRequestFailuresResponse(in []struct{ Reason string }) []requestFailureRes
 		resp[i] = requestFailureResponse{Reason: v.Reason}
 	}
 	return resp
-}
-
-type progressResponse struct {
-	ID        int           `json:"id"`
-	Done      bool          `json:"done"`
-	Error     error         `json:"error"`
-	DoneCount int           `json:"doneCount"`
-	MaxCount  int           `json:"maxCount"`
-	Timeout   time.Duration `json:"timeout"`
-	Elapsed   time.Duration `json:"elapsed"`
-}
-
-func (resp progressResponse) EncodeJSON(w io.Writer) error {
-	return json.NewEncoder(w).Encode(resp)
-}
-
-func toProgressResponse(in runner.RecordingProgress) progressResponse {
-	return progressResponse{
-		ID:        in.ID,
-		Done:      in.Done,
-		Error:     in.Error,
-		DoneCount: in.DoneCount,
-		MaxCount:  in.MaxCount,
-		Timeout:   in.Timeout,
-		Elapsed:   in.Elapsed,
-	}
-}
-
-type errorResponse struct {
-	Error error `json:"error"`
-}
-
-func (resp errorResponse) EncodeJSON(w io.Writer) error {
-	return json.NewEncoder(w).Encode(resp)
-}
-
-func toErrorResponse(err error) errorResponse {
-	return errorResponse{Error: err}
 }

--- a/cmd/server/response/response.go
+++ b/cmd/server/response/response.go
@@ -1,0 +1,18 @@
+package response
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Response struct {
+	payload interface{}
+}
+
+func (r Response) EncodeJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(r.payload)
+}
+
+func newResponse(payload interface{}) Response {
+	return Response{payload: payload}
+}

--- a/runner/internal/metrics/aggregate.go
+++ b/runner/internal/metrics/aggregate.go
@@ -7,6 +7,8 @@ import (
 	"github.com/benchttp/engine/runner/internal/recorder"
 )
 
+type TimeStats = timestats.TimeStats
+
 // Aggregate is an aggregate of metrics computed from
 // a slice of recorder.Record.
 type Aggregate struct {

--- a/runner/internal/recorder/progress.go
+++ b/runner/internal/recorder/progress.go
@@ -17,7 +17,6 @@ const (
 
 // Progress represents the progression of a recording at a given time.
 type Progress struct {
-	ID                  int
 	Done                bool
 	Error               error
 	DoneCount, MaxCount int

--- a/runner/internal/recorder/recorder.go
+++ b/runner/internal/recorder/recorder.go
@@ -123,11 +123,11 @@ func (r *Recorder) ping(req *http.Request) error {
 // to decoding the response body. In that cas invalidating the entire response,
 // as it is not a remote server error.
 type Record struct {
-	Time   time.Duration `json:"time"`
-	Code   int           `json:"code"`
-	Bytes  int           `json:"bytes"`
-	Error  string        `json:"error,omitempty"`
-	Events []Event       `json:"events"`
+	Time   time.Duration
+	Code   int
+	Bytes  int
+	Error  string
+	Events []Event
 }
 
 func (r *Recorder) recordSingle(req *http.Request, interval time.Duration) func() {

--- a/runner/internal/recorder/tracer.go
+++ b/runner/internal/recorder/tracer.go
@@ -10,8 +10,8 @@ import (
 
 // Event is a stage of an outgoing HTTP request associated with a timestamp.
 type Event struct {
-	Name string        `json:"name"`
-	Time time.Duration `json:"time"`
+	Name string
+	Time time.Duration
 }
 
 // tracer is a http.RoundTripper to be used as a http.Transport

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -23,11 +23,17 @@ type (
 
 	Report = report.Report
 
-	MetricsField = metrics.Field
-	MetricsValue = metrics.Value
+	MetricsAggregate = metrics.Aggregate
+	MetricsField     = metrics.Field
+	MetricsValue     = metrics.Value
+	MetricsTimeStats = metrics.TimeStats
 
-	TestCase      = tests.Case
-	TestPredicate = tests.Predicate
+	TestCase         = tests.Case
+	TestPredicate    = tests.Predicate
+	TestSuiteResults = tests.SuiteResult
+	TestCaseResult   = tests.CaseResult
+
+	ReportMetadata = report.Metadata
 )
 
 const (


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Note: all keys are in lower camel-case format, except request event names.
The reason is they are identifiers, not just keys, and they're used as-is by the front-end.

<details>
<summary>Progress output example</summary>
<pre lang="json">
{
  "done": false,
  "error": null,
  "doneCount": 3,
  "maxCount": 5,
  "timeout": 30000000000,
  "elapsed": 500576066
}

</pre>
</details>

<details>
<summary>Report output example</summary>
<pre lang="json">
{
  "metadata": {
    "finishedAt": "2022-09-09T18:03:45.216544+02:00",
    "totalDuration": 1004402876
  },
  "metrics": {
    "responseTimes": {
      "min": 80761084,
      "max": 333827332,
      "mean": 131707239,
      "median": 81239959,
      "standardDeviation": 101060311,
      "quartiles": [81235163, 81239959, 81472659, 333827332],
      "deciles": null
    },
    "statusCodesDistribution": { "200": 5 },
    "requestEventTimes": {
      "BodyRead": {
        "min": 80761084,
        "max": 333827332,
        "mean": 131707239,
        "median": 81239959,
        "standardDeviation": 101060311,
        "quartiles": [81235163, 81239959, 81472659, 333827332],
        "deciles": null
      },
      "ConnectDone": {
        "min": 82509680,
        "max": 82509680,
        "mean": 82509680,
        "median": 82509680,
        "standardDeviation": 0,
        "quartiles": null,
        "deciles": null
      },
      "DNSDone": {
        "min": 1210949,
        "max": 1210949,
        "mean": 1210949,
        "median": 1210949,
        "standardDeviation": 0,
        "quartiles": null,
        "deciles": null
      },
      "GotFirstResponseByte": {
        "min": 80609188,
        "max": 333639052,
        "mean": 131536899,
        "median": 81075030,
        "standardDeviation": 101051349,
        "quartiles": [81017510, 81075030, 81343718, 333639052],
        "deciles": null
      },
      "TLSHandshakeDone": {
        "min": 251534759,
        "max": 251534759,
        "mean": 251534759,
        "median": 251534759,
        "standardDeviation": 0,
        "quartiles": null,
        "deciles": null
      },
      "WroteHeaders": {
        "min": 103660,
        "max": 251729725,
        "mean": 50450882,
        "median": 126524,
        "standardDeviation": 100639424,
        "quartiles": [116665, 126524, 177839, 251729725],
        "deciles": null
      },
      "WroteRequest": {
        "min": 110456,
        "max": 251730332,
        "mean": 50453061,
        "median": 127795,
        "standardDeviation": 100638638,
        "quartiles": [117407, 127795, 179316, 251730332],
        "deciles": null
      }
    },
    "records": [
      { "responseTime": 333827332 },
      { "responseTime": 81472659 },
      { "responseTime": 81235163 },
      { "responseTime": 81239959 },
      { "responseTime": 80761084 }
    ],
    "requestFailures": [],
    "requestCount": 5,
    "requestSuccessCount": 5,
    "requestFailureCount": 0
  },
  "tests": {
    "pass": false,
    "results": [
      {
        "pass": true,
        "summary": "want ResponseTimes.Min \u003e 80ms, got 80.761084ms",
        "input": {
          "name": "minimum response time",
          "field": "ResponseTimes.Min",
          "predicate": "GT",
          "target": 80000000
        }
      },
      {
        "pass": false,
        "summary": "want ResponseTimes.Max \u003c= 120ms, got 333.827332ms",
        "input": {
          "name": "maximum response time",
          "field": "ResponseTimes.Max",
          "predicate": "LTE",
          "target": 120000000
        }
      },
      {
        "pass": false,
        "summary": "want RequestFailureCount == 5, got 0",
        "input": {
          "name": "100% availability",
          "field": "RequestFailureCount",
          "predicate": "EQ",
          "target": 5
        }
      }
    ]
  }
}

</pre>
</details>
<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

API changes:
- add new fields to json response:
  - requestCount
  - requestSuccessCount
  - requestFailureCount
- change field name for timestats: stdDev -> standardDeviation
- remove report.metadata.config: source of trouble & confusion due to input and output types being different (e.g. `string` for tests targets in input, but `time.Duration` in output, or `string` for request.url in input and `url.URL` object in output, ...). Also we don't have a use-case for it.
- remove progress.id: unused

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
