### PR TITLE
fix: reflectpath.Resolver.ResolveValue incorrectly panics

### DIFF
--- a/runner/internal/reflectpath/value.go
+++ b/runner/internal/reflectpath/value.go
@@ -85,22 +85,22 @@ func mapIndexFunc(host reflect.Value, match func(string) bool) reflect.Value {
 			panic(fmt.Sprintf("unhandled key kind: %s", keyKind))
 		}
 	}
-	return zeroValueOfElem(host)
+	return zeroValueElemOf(host)
 }
 
 func sliceIndex(host reflect.Value, istr string) reflect.Value {
 	i, err := strconv.Atoi(istr)
 	if err != nil || i >= host.Len() {
-		return zeroValueOfElem(host)
+		return zeroValueElemOf(host)
 	}
 	if elemMatch := host.Index(i); elemMatch.IsValid() {
 		return elemMatch
 	}
-	return zeroValueOfElem(host)
+	return zeroValueElemOf(host)
 }
 
 // zeroValueOfElem returns the zero value of the element type of host.
 // It panics if host is not a slice or map.
-func zeroValueOfElem(host reflect.Value) reflect.Value {
+func zeroValueElemOf(host reflect.Value) reflect.Value {
 	return reflect.Zero(host.Elem().Type())
 }

--- a/runner/internal/reflectpath/value.go
+++ b/runner/internal/reflectpath/value.go
@@ -85,16 +85,22 @@ func mapIndexFunc(host reflect.Value, match func(string) bool) reflect.Value {
 			panic(fmt.Sprintf("unhandled key kind: %s", keyKind))
 		}
 	}
-	return reflect.Value{}
+	return zeroValueOfElem(host)
 }
 
 func sliceIndex(host reflect.Value, istr string) reflect.Value {
 	i, err := strconv.Atoi(istr)
 	if err != nil || i >= host.Len() {
-		return reflect.Value{}
+		return zeroValueOfElem(host)
 	}
 	if elemMatch := host.Index(i); elemMatch.IsValid() {
 		return elemMatch
 	}
-	return reflect.Value{}
+	return zeroValueOfElem(host)
+}
+
+// zeroValueOfElem returns the zero value of the element type of host.
+// It panics if host is not a slice or map.
+func zeroValueOfElem(host reflect.Value) reflect.Value {
+	return reflect.Zero(host.Elem().Type())
 }

--- a/runner/internal/reflectpath/value.go
+++ b/runner/internal/reflectpath/value.go
@@ -81,9 +81,11 @@ func mapIndexFunc(host reflect.Value, match func(string) bool) reflect.Value {
 			if match(strconv.Itoa(int(key.Int()))) {
 				return iter.Value()
 			}
+		default:
+			panic(fmt.Sprintf("unhandled key kind: %s", keyKind))
 		}
 	}
-	panic(fmt.Sprintf("unhandled key kind: %s", keyKind))
+	return reflect.Value{}
 }
 
 func sliceIndex(host reflect.Value, istr string) reflect.Value {


### PR DESCRIPTION
## Description

When configuring a test case on a metric accessed through a field which is a map or a slice, and if that map's key or slice's index does not exist on the `Aggregate` (expected behavior, see example), accessing that value through `reflectpath.Resolver.ResolveValue` panics.

As this is an expected usecase, panicking is a runtime bug.

## Example

```json
  "tests": [
    {
      "name": "My endpoint has no latency",
      "field": "RequestEventTimes.ConnectDone.Max", // expected to always exist
      "predicate": "LT",
      "target": "250ms"
    },
    {
      "name": "My endpoint has enough teapots",
      "field": "StatusCodesDistribution.418", // expected to not exist if remote server does not return 418
      "predicate": "GT",
      "target": 10
    }
  ]
```

## Changes

- Only panic when reading a key of unsupported type, this is done as the `default` case when switching on `host.Type().Key().Kind()`.
- Return the zero value of the type of the map/slice's element to work with `metrics.Metric.Compare`
```go
// Not returning element's zero value
val := metrics.MetricOf("StatusCodesDistribution.418")
// val == reflect.Value{}
res := val.Compare(10)
// panic: "unhandled comparison: 10 (int) and invalid (reflect.Value)"


// Returning element's zero value
val := metrics.MetricOf("StatusCodesDistribution.418")
// val == 0 as host.418 does not exist
res := val.Compare(10)
// res == metrics.INF
```
