### PR TITLE
ci: dispatch update to benchttp/desktop

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,4 +1,4 @@
-name: Dispatch update-engine to benchttp/desktop
+name: Dispatch update to benchttp/desktop
 
 on:
   push:
@@ -10,6 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create workflow_dispatch event
-        run: echo ${{ env.PAYLOAD }} | gh workflow run --repo benchttp/desktop update-engine.yml
-        env:
-          PAYLOAD: '{"sha": "${{ github.sha }}"}'
+        run: gh workflow run --repo benchttp/desktop update-engine.yml --ref main -f sha=${{ github.sha }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,15 @@
+name: Dispatch update-engine to benchttp/desktop
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create workflow_dispatch event
+        run: echo ${{ env.PAYLOAD }} | gh workflow run --repo benchttp/desktop update-engine.yml
+        env:
+          PAYLOAD: '{"sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Description
On merge to `main`, triggers a workflow dispatch to benchttp/desktop to update the vendored version of `engine` to latest. Passes the sha as a input to uniquely identify the workflow.

See benchttp/desktop#54.
