### PR TITLE
feat(tests): retrieve got value

### DIFF
--- a/cmd/server/response/report.go
+++ b/cmd/server/response/report.go
@@ -46,9 +46,9 @@ type testsResponse struct {
 }
 
 type testResultResponse struct {
-	Pass    bool              `json:"pass"`
-	Summary string            `json:"summary"`
-	Input   testInputResponse `json:"input"`
+	Pass  bool              `json:"pass"`
+	Got   interface{}       `json:"got"`
+	Input testInputResponse `json:"input"`
 }
 
 type testInputResponse struct {
@@ -91,8 +91,8 @@ func toTestResultsResponse(testResults []runner.TestCaseResult) []testResultResp
 	resp := make([]testResultResponse, len(testResults))
 	for i, r := range testResults {
 		resp[i] = testResultResponse{
-			Pass:    r.Pass,
-			Summary: r.Summary,
+			Pass: r.Pass,
+			Got:  r.Got,
 			Input: testInputResponse{
 				Name:      r.Input.Name,
 				Field:     string(r.Input.Field),

--- a/runner/internal/tests/tests.go
+++ b/runner/internal/tests/tests.go
@@ -21,6 +21,7 @@ type SuiteResult struct {
 type CaseResult struct {
 	Input   Case
 	Pass    bool
+	Got     metrics.Value
 	Summary string
 }
 
@@ -48,6 +49,7 @@ func runTestCase(agg metrics.Aggregate, c Case) CaseResult {
 	return CaseResult{
 		Input: c,
 		Pass:  c.Predicate.match(comparisonResult),
+		Got:   gotMetric.Value,
 		Summary: fmt.Sprintf(
 			"want %s %s %v, got %v",
 			c.Field, c.Predicate.symbol(), c.Target, gotMetric.Value,

--- a/runner/internal/tests/tests_test.go
+++ b/runner/internal/tests/tests_test.go
@@ -70,16 +70,23 @@ func TestRun(t *testing.T) {
 		t.Run(tc.label, func(t *testing.T) {
 			suiteResult := tests.Run(tc.inputAgg, tc.inputCases)
 
-			if gotGlobalPass := suiteResult.Pass; gotGlobalPass != tc.expGlobalPass {
-				t.Errorf(
-					"exp global pass == %v, got %v",
-					gotGlobalPass, tc.expGlobalPass,
-				)
-			}
-
+			assertGlobalPass(t, suiteResult.Pass, tc.expGlobalPass)
 			assertEqualCaseResults(t, tc.expCaseResults, suiteResult.Results)
 		})
 	}
+}
+
+func assertGlobalPass(t *testing.T, got, exp bool) {
+	t.Helper()
+
+	t.Run("global pass", func(t *testing.T) {
+		if exp != got {
+			t.Errorf(
+				"exp global pass == %v, got %v",
+				exp, got,
+			)
+		}
+	})
 }
 
 func assertEqualCaseResults(t *testing.T, exp, got []tests.CaseResult) {

--- a/runner/internal/tests/tests_test.go
+++ b/runner/internal/tests/tests_test.go
@@ -37,8 +37,8 @@ func TestRun(t *testing.T) {
 			},
 			expGlobalPass: true,
 			expCaseResults: []tests.CaseResult{
-				{Pass: true, Summary: "want ResponseTimes.Mean < 120ms, got 100ms"},
-				{Pass: true, Summary: "want ResponseTimes.Mean > 80ms, got 100ms"},
+				{Pass: true, Got: ms(100), Summary: "want ResponseTimes.Mean < 120ms, got 100ms"},
+				{Pass: true, Got: ms(100), Summary: "want ResponseTimes.Mean > 80ms, got 100ms"},
 			},
 		},
 		{
@@ -60,8 +60,8 @@ func TestRun(t *testing.T) {
 			},
 			expGlobalPass: false,
 			expCaseResults: []tests.CaseResult{
-				{Pass: false, Summary: "want ResponseTimes.Mean < 120ms, got 200ms"},
-				{Pass: true, Summary: "want ResponseTimes.Mean > 80ms, got 200ms"},
+				{Pass: false, Got: ms(200), Summary: "want ResponseTimes.Mean < 120ms, got 200ms"},
+				{Pass: true, Got: ms(200), Summary: "want ResponseTimes.Mean > 80ms, got 200ms"},
 			},
 		},
 	}
@@ -98,6 +98,15 @@ func assertEqualCaseResults(t *testing.T, exp, got []tests.CaseResult) {
 				t.Errorf(
 					"\n%s:\nexp %v, got %v",
 					caseDesc, expResult.Pass, gotResult.Pass,
+				)
+			}
+		})
+
+		t.Run(fmt.Sprintf("cases[%d].Got", i), func(t *testing.T) {
+			if gotResult.Got != expResult.Got {
+				t.Errorf(
+					"\n%s:\nexp %v, got %v",
+					caseDesc, expResult.Got, gotResult.Got,
 				)
 			}
 		})


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Update server response for field `tests.results[i]`:
- Add `got`, representing the value the input target is tested against
- Remove `summary`

### Before

```json
{
  "tests": {
    "pass": false,
    "results": [
      {
        "pass": true,
        "summary": "want ResponseTimes.Min > 80ms, got 80.761084ms",
        "input": {
          "name": "minimum response time",
          "field": "ResponseTimes.Min",
          "predicate": "GT",
          "target": 80000000
        }
      }
    ]
  }
}
```

### After

```json
{
  "tests": {
    "pass": false,
    "results": [
      {
        "pass": true,
        "got": 80128242,
        "input": {
          "name": "minimum response time",
          "field": "ResponseTimes.Min",
          "predicate": "GT",
          "target": 80000000
        }
      }
    ]
  }
}
```



<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
