### PR TITLE
chore: rename package back to `engine`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,7 +111,7 @@ linters-settings:
     extra-rules: true
 
   goimports:
-    local-prefixes: github.com/benchttp/sdk
+    local-prefixes: github.com/benchttp/engine
 
   misspell:
     locale: US

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
     <img alt="Github Worklow Status" src="https://img.shields.io/github/actions/workflow/status/benchttp/engine/ci.yml?branch=main"></a>
   <a href="https://codecov.io/gh/benchttp/engine">
     <img alt="Code coverage" src="https://img.shields.io/codecov/c/gh/benchttp/engine?label=coverage"></a>
-  <a href="https://goreportcard.com/report/github.com/benchttp/sdk">
-    <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/benchttp/sdk" /></a>
+  <a href="https://goreportcard.com/report/github.com/benchttp/engine">
+    <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/benchttp/engine" /></a>
   <br />
-  <a href="https://pkg.go.dev/github.com/benchttp/sdk#section-documentation">
+  <a href="https://pkg.go.dev/github.com/benchttp/engine#section-documentation">
     <img alt="Go package Reference" src="https://img.shields.io/badge/pkg-reference-informational?logo=go" /></a>
-  <a href="https://github.com/benchttp/sdk/releases">
+  <a href="https://github.com/benchttp/engine/releases">
     <img alt="Latest version" src="https://img.shields.io/github/v/tag/benchttp/engine?label=release"></a>
 </p>
 
@@ -28,7 +28,7 @@ Go1.17 environment or higher is required.
 Install.
 
 ```txt
-go get github.com/benchttp/sdk
+go get github.com/benchttp/engine
 ```
 
 ## Usage
@@ -42,7 +42,7 @@ import (
     "context"
     "fmt"
 
-    "github.com/benchttp/sdk/benchttp"
+    "github.com/benchttp/engine/benchttp"
 )
 
 func main() {
@@ -64,8 +64,8 @@ import (
     "context"
     "fmt"
 
-    "github.com/benchttp/sdk/benchttp"
-    "github.com/benchttp/sdk/configio"
+    "github.com/benchttp/engine/benchttp"
+    "github.com/benchttp/engine/configio"
 )
 
 func main() {
@@ -90,7 +90,7 @@ func main() {
 }
 ```
 
-📄 Please refer to [our Wiki](https://github.com/benchttp/sdk/wiki/IO-Structures) for exhaustive `Runner` and `Report` structures (and more!)
+📄 Please refer to [our Wiki](https://github.com/benchttp/engine/wiki/IO-Structures) for exhaustive `Runner` and `Report` structures (and more!)
 
 ## Development
 

--- a/benchttp/error_test.go
+++ b/benchttp/error_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 func TestInvalidRunnerError(t *testing.T) {

--- a/benchttp/internal/metrics/aggregate.go
+++ b/benchttp/internal/metrics/aggregate.go
@@ -3,8 +3,8 @@ package metrics
 import (
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics/timestats"
-	"github.com/benchttp/sdk/benchttp/internal/recorder"
+	"github.com/benchttp/engine/benchttp/internal/metrics/timestats"
+	"github.com/benchttp/engine/benchttp/internal/recorder"
 )
 
 type TimeStats = timestats.TimeStats

--- a/benchttp/internal/metrics/aggregate_test.go
+++ b/benchttp/internal/metrics/aggregate_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/benchttp/internal/metrics/timestats"
-	"github.com/benchttp/sdk/benchttp/internal/recorder"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/metrics/timestats"
+	"github.com/benchttp/engine/benchttp/internal/recorder"
 )
 
 func TestNewAggregate(t *testing.T) {

--- a/benchttp/internal/metrics/field.go
+++ b/benchttp/internal/metrics/field.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"errors"
 
-	"github.com/benchttp/sdk/internal/errorutil"
+	"github.com/benchttp/engine/internal/errorutil"
 )
 
 // ErrUnknownField occurs when a Field is used with an invalid path.

--- a/benchttp/internal/metrics/field_test.go
+++ b/benchttp/internal/metrics/field_test.go
@@ -3,7 +3,7 @@ package metrics_test
 import (
 	"testing"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
 )
 
 func TestField_Type(t *testing.T) {

--- a/benchttp/internal/metrics/metrics.go
+++ b/benchttp/internal/metrics/metrics.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"strings"
 
-	"github.com/benchttp/sdk/benchttp/internal/reflectpath"
+	"github.com/benchttp/engine/benchttp/internal/reflectpath"
 )
 
 // Value is a concrete metric value, e.g. 120 or 3 * time.Second.

--- a/benchttp/internal/metrics/metrics_test.go
+++ b/benchttp/internal/metrics/metrics_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/benchttp/internal/metrics/timestats"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/metrics/timestats"
 )
 
 func TestMetric_Compare(t *testing.T) {

--- a/benchttp/internal/metrics/timestats/timestats_test.go
+++ b/benchttp/internal/metrics/timestats/timestats_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics/timestats"
+	"github.com/benchttp/engine/benchttp/internal/metrics/timestats"
 )
 
 func TestCompute(t *testing.T) {

--- a/benchttp/internal/recorder/recorder.go
+++ b/benchttp/internal/recorder/recorder.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benchttp/sdk/internal/dispatcher"
+	"github.com/benchttp/engine/internal/dispatcher"
 )
 
 const (

--- a/benchttp/internal/recorder/recorder_internal_test.go
+++ b/benchttp/internal/recorder/recorder_internal_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/internal/dispatcher"
+	"github.com/benchttp/engine/internal/dispatcher"
 )
 
 var errTest = errors.New("test-generated error")

--- a/benchttp/internal/tests/predicate.go
+++ b/benchttp/internal/tests/predicate.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"errors"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/internal/errorutil"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/internal/errorutil"
 )
 
 var ErrUnknownPredicate = errors.New("tests: unknown predicate")

--- a/benchttp/internal/tests/predicate_test.go
+++ b/benchttp/internal/tests/predicate_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/benchttp/internal/tests"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/tests"
 )
 
 func TestPredicate(t *testing.T) {

--- a/benchttp/internal/tests/tests.go
+++ b/benchttp/internal/tests/tests.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"fmt"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
 )
 
 type Case struct {

--- a/benchttp/internal/tests/tests_test.go
+++ b/benchttp/internal/tests/tests_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/benchttp/internal/metrics/timestats"
-	"github.com/benchttp/sdk/benchttp/internal/tests"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/metrics/timestats"
+	"github.com/benchttp/engine/benchttp/internal/tests"
 )
 
 func TestRun(t *testing.T) {

--- a/benchttp/report.go
+++ b/benchttp/report.go
@@ -3,8 +3,8 @@ package benchttp
 import (
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/benchttp/internal/tests"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/tests"
 )
 
 // Report represents a run result as exported by the runner.

--- a/benchttp/runner.go
+++ b/benchttp/runner.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp/internal/metrics"
-	"github.com/benchttp/sdk/benchttp/internal/recorder"
-	"github.com/benchttp/sdk/benchttp/internal/tests"
+	"github.com/benchttp/engine/benchttp/internal/metrics"
+	"github.com/benchttp/engine/benchttp/internal/recorder"
+	"github.com/benchttp/engine/benchttp/internal/tests"
 )
 
 type (

--- a/benchttp/runner_test.go
+++ b/benchttp/runner_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 func TestRunner_WithRequest(t *testing.T) {

--- a/benchttptest/compare.go
+++ b/benchttptest/compare.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 // RunnerCmpOptions is the cmp.Options used to compare benchttp.Runner.

--- a/benchttptest/compare_test.go
+++ b/benchttptest/compare_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/benchttptest"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/benchttptest"
 )
 
 func TestAssertEqualRunners(t *testing.T) {

--- a/configio/builder.go
+++ b/configio/builder.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 // A Builder is used to incrementally build a benchttp.Runner

--- a/configio/builder_test.go
+++ b/configio/builder_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/benchttptest"
-	"github.com/benchttp/sdk/configio"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/benchttptest"
+	"github.com/benchttp/engine/configio"
 )
 
 func TestBuilder_WriteJSON(t *testing.T) {

--- a/configio/decoder.go
+++ b/configio/decoder.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 type Format string

--- a/configio/error.go
+++ b/configio/error.go
@@ -27,7 +27,7 @@ var (
 )
 
 func panicInternal(funcname, detail string) {
-	const reportURL = "https://github.com/benchttp/sdk/issues/new"
+	const reportURL = "https://github.com/benchttp/engine/issues/new"
 	source := fmt.Sprintf("configio.%s", funcname)
 	panic(fmt.Sprintf(
 		"%s: unexpected internal error: %s, please file an issue at %s",

--- a/configio/example_test.go
+++ b/configio/example_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/configio"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/configio"
 )
 
 var jsonConfig = []byte(

--- a/configio/file.go
+++ b/configio/file.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 
-	"github.com/benchttp/sdk/internal/errorutil"
+	"github.com/benchttp/engine/internal/errorutil"
 )
 
 // DefaultPaths is the default list of paths looked up by FindFile when

--- a/configio/file_test.go
+++ b/configio/file_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/benchttptest"
-	"github.com/benchttp/sdk/configio"
-	"github.com/benchttp/sdk/configio/internal/testdata"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/benchttptest"
+	"github.com/benchttp/engine/configio"
+	"github.com/benchttp/engine/configio/internal/testdata"
 )
 
 func TestFindFile(t *testing.T) {

--- a/configio/internal/testdata/testdata.go
+++ b/configio/internal/testdata/testdata.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 // ConfigFile represents a testdata configuration file.

--- a/configio/json.go
+++ b/configio/json.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"regexp"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 // JSONDecoder implements Decoder

--- a/configio/json_test.go
+++ b/configio/json_test.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/configio"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/configio"
 )
 
 func TestMarshalJSON(t *testing.T) {

--- a/configio/representation.go
+++ b/configio/representation.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/internal/errorutil"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/internal/errorutil"
 )
 
 // representation is a raw data model for formatted runner config (json, yaml).

--- a/configio/yaml.go
+++ b/configio/yaml.go
@@ -9,7 +9,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/benchttp/sdk/benchttp"
+	"github.com/benchttp/engine/benchttp"
 )
 
 // YAMLDecoder implements Decoder

--- a/configio/yaml_test.go
+++ b/configio/yaml_test.go
@@ -8,8 +8,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/benchttp/sdk/benchttp"
-	"github.com/benchttp/sdk/configio"
+	"github.com/benchttp/engine/benchttp"
+	"github.com/benchttp/engine/configio"
 )
 
 func TestYAMLDecoder(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/benchttp/sdk
+module github.com/benchttp/engine
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,3 @@ require (
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require github.com/google/go-cmp v0.5.9

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benchttp/sdk/internal/dispatcher"
+	"github.com/benchttp/engine/internal/dispatcher"
 )
 
 func TestNew(t *testing.T) {

--- a/script/doc
+++ b/script/doc
@@ -5,7 +5,7 @@ port="9995"
 addr="${domain}:${port}"
 
 main() {
-  echo "http://${addr}/pkg/github.com/benchttp/sdk/"
+  echo "http://${addr}/pkg/github.com/benchttp/engine/"
   godoc -http="${addr}"
 }
 main


### PR DESCRIPTION
## Description

Closes #68.

Previous changes were made with the intent of renaming the repo as `sdk`. After reconsideration, we no longer wish to go with that name. Until we find a better one, we go back to `engine`.

## Changes

- change all occurrences of `sdk` to `engine`
- run `go mod tidy` (misc)